### PR TITLE
generate lower-case URLs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -10,7 +10,7 @@ timezone: Europe/Berlin
 encoding: UTF-8
 
 future: true
-permalink: /blog/:year/:month/:day/:title.html
+permalink: /blog/:year/:month/:day/:slug.html
 url: http://bremen.freifunk.net
 
 paginate: 5


### PR DESCRIPTION
Keine Ahnung, wie im Moment bei http://bremen.freifunk.net/ die kleingeschriebenen Blogpost-URLs generiert werden; aber mit dieser Änderungen funktionierts ebenfalls. Eine zuverlässige Methode. um diese URLs zu generieren, ist nötig, wenn wir den Server frisch neu aufsetzen (s. https://github.com/FreifunkBremen/ansible/pull/38).

Ich hab mit `wget --mirror` und `diff -r` überprüft, dass die generierten HTML-Dateien identisch sind mit denen auf http://bremen.freifunk.net/.