### PR TITLE
Force http for wiki.bremen.freifunk.net

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -42,7 +42,7 @@
         <ul class="nav navbar-nav">
           <li><a href="/">Home</a></li>
           <li><a href="/blog/">Blog</a></li>
-          <li><a href="//wiki.bremen.freifunk.net" target="_blank">Wiki</a></li>
+          <li><a href="http://wiki.bremen.freifunk.net" target="_blank">Wiki</a></li>
           <li><a href="/map/meshviewer.html" target="_blank">Netzkarte</a></li>
           <li><a href="/refugees.html">Geflüchtete</a></li>
           <li><a href="/faq.html">Häufige Fragen</a></li>


### PR DESCRIPTION
https of the wiki is broken

It would be better to fix https