### PR TITLE
blog, new post: Gluon wechselt Softwarebasis

### DIFF
--- a/_posts/2017-06-12-Gluon-wechselt-Softwarebasis.md
+++ b/_posts/2017-06-12-Gluon-wechselt-Softwarebasis.md
@@ -4,14 +4,14 @@ title:  "Gluon wechselt Softwarebasis"
 author: SimJoSt
 date:   2017-06-12 16:55:21 +0200
 ---
-Vor etwas über einem Jahr gab es einen Umbruch in der Entwicklergemeinde von OpenWRT, ein Projekt für Linux-Router-Software, auf dem Gluon und auf welchem wiederum unsere Bremer Firmware basiert. Wegen langsamen Fortschritt und träger Strukturen, organisierten sich die meisten Hauptentwickler unter dem neuen Namen "[LEDE](https://lede-project.org/about)".  
+Vor etwas über einem Jahr gab es einen Umbruch in der Entwicklergemeinde von OpenWRT, einem Projekt für Linux-Router-Software, auf dem Gluon und auf welchem wiederum unsere Bremer Firmware basiert. Wegen langsamem Fortschritt und träger Strukturen organisierten sich die meisten Hauptentwickler unter dem neuen Namen "[LEDE](https://lede-project.org/about)".  
 Ziel war mehr Aktivität der Entwickler sowie einfachere und dynamischere Strukturen.
 
-In der Vergangenheit wurden angebotene Weiterentwicklungen wohl regelmäßig nicht geprüft und wurden so auch nie in die Software übernommen. Diese Tatsache hat eine Menge Entwickler demotiviert Arbeit für das Projekt zu leisten.  
+In der Vergangenheit wurden angebotene Weiterentwicklungen wohl regelmäßig nicht geprüft und wurden so auch nie in die Software übernommen. Diese Tatsache hat eine Menge Entwickler demotiviert, Arbeit für das Projekt zu leisten.  
 OpenWRT wurde nur noch von ein paar wenigen weiterentwickelt und in vielen Kreisen als tot angesehen. Im Gegensatz dazu nahm die Entwicklung in LEDE richtig Fahrt auf. In kurzer Zeit wurden sehr viele Beiträge eingereicht und aufgenommen.
 
 Diese Entwicklung war gerade auch für das von uns genutzte [Gluon](https://gluon.readthedocs.io/) spannend. Fehlerbehebungen, Unterstützung für weitere Geräte sowie die Möglichkeit von neuen Technologien, oft auch eingereicht von Gluon-Entwicklern, machten LEDE zum Ziel für die nächste Basis für Gluon.  
 Anfang 2017 wurden die ersten LEDE-Vorab- sowie stabilen Versionen veröffentlicht und in Gluon ging der Endspurt zu einer Veröffentlichung von Gluon 2017.1 mit der neuen Basis los.
 
-Am letzten Samstag war es dann soweit: Gluon veröffentlichte die letzte Version auf der alten Basis sowie eine erste Version auf der neuen Basis!  
+Am letzten Samstag war es dann soweit: Gluon veröffentlichte die [letzte Version auf der alten Basis](http://gluon.readthedocs.io/en/v2016.2.6/releases/v2016.2.6.html) sowie eine [erste Version auf der neuen Basis](http://gluon.readthedocs.io/en/v2017.1/releases/v2017.1.html)!  
 Wir freuen uns über das neu entfachte Engagement und viele neue Firmwareversionen.

--- a/_posts/2017-06-12-Gluon-wechselt-Softwarebasis.md
+++ b/_posts/2017-06-12-Gluon-wechselt-Softwarebasis.md
@@ -1,0 +1,17 @@
+---
+layout: post
+title:  "Gluon wechselt Softwarebasis"
+author: SimJoSt
+date:   2017-06-12 16:55:21 +0200
+---
+Vor etwas über einem Jahr gab es einen Umbruch in der Entwicklergemeinde von OpenWRT, ein Projekt für Linux-Router-Software, auf dem Gluon und auf welchem wiederum unsere Bremer Firmware basiert. Wegen langsamen Fortschritt und träger Strukturen, organisierten sich die meisten Hauptentwickler unter dem neuen Namen "[LEDE](https://lede-project.org/about)".  
+Ziel war mehr Aktivität der Entwickler sowie einfachere und dynamischere Strukturen.
+
+In der Vergangenheit wurden angebotene Weiterentwicklungen wohl regelmäßig nicht geprüft und wurden so auch nie in die Software übernommen. Diese Tatsache hat eine Menge Entwickler demotiviert Arbeit für das Projekt zu leisten.  
+OpenWRT wurde nur noch von ein paar wenigen weiterentwickelt und in vielen Kreisen als tot angesehen. Im Gegensatz dazu nahm die Entwicklung in LEDE richtig Fahrt auf. In kurzer Zeit wurden sehr viele Beiträge eingereicht und aufgenommen.
+
+Diese Entwicklung war gerade auch für das von uns genutzte [Gluon](https://gluon.readthedocs.io/) spannend. Fehlerbehebungen, Unterstützung für weitere Geräte sowie die Möglichkeit von neuen Technologien, oft auch eingereicht von Gluon-Entwicklern, machten LEDE zum Ziel für die nächste Basis für Gluon.  
+Anfang 2017 wurden die ersten LEDE-Vorab- sowie stabilen Versionen veröffentlicht und in Gluon ging der Endspurt zu einer Veröffentlichung von Gluon 2017.1 mit der neuen Basis los.
+
+Am letzten Samstag war es dann soweit: Gluon veröffentlichte die letzte Version auf der alten Basis sowie eine erste Version auf der neuen Basis!  
+Wir freuen uns über das neu entfachte Engagement und viele neue Firmwareversionen.

--- a/_posts/2017-06-13-Gluon-wechselt-Softwarebasis.md
+++ b/_posts/2017-06-13-Gluon-wechselt-Softwarebasis.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Gluon wechselt Softwarebasis"
 author: SimJoSt
-date:   2017-06-13 11:55:21 +0200
+date:   2017-06-13 11:59:21 +0200
 ---
 Vor etwas über einem Jahr gab es einen Umbruch in der Entwicklergemeinde von OpenWrt, einem Projekt für Linux-Router-Software, auf dem Gluon und auf welchem wiederum unsere Bremer Firmware basiert. Wegen langsamem Fortschritt und träger Strukturen organisierten sich die meisten Hauptentwickler unter dem neuen Namen "[LEDE](https://lede-project.org/about)".  
 Ziel war mehr Aktivität der Entwickler sowie einfachere und dynamischere Strukturen.

--- a/_posts/2017-06-13-Gluon-wechselt-Softwarebasis.md
+++ b/_posts/2017-06-13-Gluon-wechselt-Softwarebasis.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Gluon wechselt Softwarebasis"
 author: SimJoSt
-date:   2017-06-12 16:55:21 +0200
+date:   2017-06-13 11:55:21 +0200
 ---
 Vor etwas über einem Jahr gab es einen Umbruch in der Entwicklergemeinde von OpenWRT, einem Projekt für Linux-Router-Software, auf dem Gluon und auf welchem wiederum unsere Bremer Firmware basiert. Wegen langsamem Fortschritt und träger Strukturen organisierten sich die meisten Hauptentwickler unter dem neuen Namen "[LEDE](https://lede-project.org/about)".  
 Ziel war mehr Aktivität der Entwickler sowie einfachere und dynamischere Strukturen.

--- a/_posts/2017-06-13-Gluon-wechselt-Softwarebasis.md
+++ b/_posts/2017-06-13-Gluon-wechselt-Softwarebasis.md
@@ -4,14 +4,17 @@ title:  "Gluon wechselt Softwarebasis"
 author: SimJoSt
 date:   2017-06-13 11:55:21 +0200
 ---
-Vor etwas über einem Jahr gab es einen Umbruch in der Entwicklergemeinde von OpenWRT, einem Projekt für Linux-Router-Software, auf dem Gluon und auf welchem wiederum unsere Bremer Firmware basiert. Wegen langsamem Fortschritt und träger Strukturen organisierten sich die meisten Hauptentwickler unter dem neuen Namen "[LEDE](https://lede-project.org/about)".  
+Vor etwas über einem Jahr gab es einen Umbruch in der Entwicklergemeinde von OpenWrt, einem Projekt für Linux-Router-Software, auf dem Gluon und auf welchem wiederum unsere Bremer Firmware basiert. Wegen langsamem Fortschritt und träger Strukturen organisierten sich die meisten Hauptentwickler unter dem neuen Namen "[LEDE](https://lede-project.org/about)".  
 Ziel war mehr Aktivität der Entwickler sowie einfachere und dynamischere Strukturen.
 
 In der Vergangenheit wurden angebotene Weiterentwicklungen wohl regelmäßig nicht geprüft und wurden so auch nie in die Software übernommen. Diese Tatsache hat eine Menge Entwickler demotiviert, Arbeit für das Projekt zu leisten.  
-OpenWRT wurde nur noch von ein paar wenigen weiterentwickelt und in vielen Kreisen als tot angesehen. Im Gegensatz dazu nahm die Entwicklung in LEDE richtig Fahrt auf. In kurzer Zeit wurden sehr viele Beiträge eingereicht und aufgenommen.
+OpenWrt wurde nur noch von ein paar wenigen weiterentwickelt und in vielen Kreisen als tot angesehen. Im Gegensatz dazu nahm die Entwicklung in LEDE richtig Fahrt auf. In kurzer Zeit wurden sehr viele Beiträge eingereicht und aufgenommen.
 
 Diese Entwicklung war gerade auch für das von uns genutzte [Gluon](https://gluon.readthedocs.io/) spannend. Fehlerbehebungen, Unterstützung für weitere Geräte sowie die Möglichkeit von neuen Technologien, oft auch eingereicht von Gluon-Entwicklern, machten LEDE zum Ziel für die nächste Basis für Gluon.  
 Anfang 2017 wurden die ersten LEDE-Vorab- sowie stabilen Versionen veröffentlicht und in Gluon ging der Endspurt zu einer Veröffentlichung von Gluon 2017.1 mit der neuen Basis los.
 
 Am letzten Samstag war es dann soweit: Gluon veröffentlichte die [letzte Version auf der alten Basis](http://gluon.readthedocs.io/en/v2016.2.6/releases/v2016.2.6.html) sowie eine [erste Version auf der neuen Basis](http://gluon.readthedocs.io/en/v2017.1/releases/v2017.1.html)!  
-Wir freuen uns über das neu entfachte Engagement und viele neue Firmwareversionen.
+
+Aktuell wird von den Entwicklern von LEDE und OpenWrt bereits über einer Wiedervereinigung (remerge) gesprochen. Die neue Infrastruktur und der Elan sowie die Codebasis wird man in Zukunft wohl unter dem bereits weit verbreiteten und bekannten Namen OpenWrt weiterführen.
+
+Wir freuen uns auf jeden Fall über das neu entfachte Engagement und viele neue Firmwareversionen.


### PR DESCRIPTION
Erklärt das Entstehen von LEDE, dessen groben Verlauf des letzten Jahres und den jetzigen Umstieg von Gluon auf LEDE.
Ich bitte um groben fact check und das Überprüfen der Lesbarkeit. An einem Stück runtergeschrieben.