### PR TITLE
Bilder mit jekyll-image-tag skalieren

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@
 source 'https://rubygems.org'
 gem 'jekyll', '>= 3.8.4'
 gem 'uglifier'
+gem 'mini_magick'

--- a/README.md
+++ b/README.md
@@ -2,6 +2,28 @@
 
 Dies ist der Inhalt von https://bremen.freifunk.net. Die Seite wird mit [Jekyll](http://jekyllrb.com) gepflegt. Seiteninhalte werden in [Markdown](http://markdown.de/syntax/) geschrieben und dann von Jekyll automatisch in HTML umgewandelt.
 
+## Bilder einbinden
+Bilder für Blogposts sollten unter blog/files/ eingecheckt werden; Bilder für andere Teile der Seite sollten unter images/ eingecheckt werden.
+
+Die Bilder sollten vor dem Einchecken vorbereitet werden:
+- Bild z.B. auf FullHD-Auflösung (1920 Pixel breit) runterskalieren
+- JPEG-Qualität auf 95% setzen
+- Metadaten entfernen (unter Linux: `exiftool -all= <Bilddatei>`)
+
+Um Bilder in Blogposts einzubinden, sollte das `image`-Jekyll-Tag verwendet werden, ungefähr so:
+```
+{% image 800xAUTO blog/files/2018-11-22/einbild.jpg width="400" alt="Eine Beschreibung des Bildes" %}
+```
+
+Damit wird das Bild mittels [jekyll-image-tag](https://github.com/robwierzbowski/jekyll-image-tag) auf die angegebene Größe skaliert, was die Ladezeit reduziert. Im Beispiel wird das Bild auf 800 Pixel Breite und die dazu passende Höhe skaliert, und wird dann mit 400 Pixeln Breite dargestellt. Die Verdoppelung der Größe ist sinnvoll, um das Bild auch auf High-DPI-Bildschirmen und beim Zoomen scharf anzuzeigen.
+
+Für Bilder, die anhand der Höhe (statt Breite) skaliert werden sollen, würde das `ìmage`-Tag so aussehen:
+```
+{% image AUTOx800 blog/files/2018-11-22/einbild.jpg style="max-height:400px" alt="Eine Beschreibung des Bildes" %}
+```
+Die `max-height`-Angabe sorgt dafür, dass das Bild korrekt angezeigt wird, auch wenn es von der Breite nicht mehr auf den Bildschirm passt.
+
+
 ## Lokale Kopie ##
 
 Mit diesen Schritten kann man die Freifunk-Webseite auf dem eigenen Rechner ansehen und testen:

--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,7 @@ encoding: UTF-8
 
 permalink: /blog/:year/:month/:day/:slug.html
 url: http://bremen.freifunk.net
+baseurl: /
 
 exclude: ['wiki', 'README.md', 'Gemfile', 'Gemfile.lock', 'api/config.php.example', 'images/icons', 'vendor']
 keep_files: ['.htaccess', 'webhook.php', 'in_freifunk.php', 'meshviewer', 'api/config.php', 'api/cache/']
@@ -18,6 +19,13 @@ kramdown:
 
 sass:
     style: compressed
+
+image:
+  output: generated
+  presets:
+    dummy:
+      width: 400
+      height: 400
 
 defaults:
   - scope:

--- a/_plugins/image_tag.LICENSE.txt
+++ b/_plugins/image_tag.LICENSE.txt
@@ -1,0 +1,24 @@
+Copyright (c) 2013, Robert Wierzbowski
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL <COPYRIGHT HOLDER> BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/_plugins/image_tag.rb
+++ b/_plugins/image_tag.rb
@@ -1,0 +1,176 @@
+# Title: Jekyll Image Tag
+# Authors: Rob Wierzbowski : @robwierzbowski
+#
+# Description: Better images for Jekyll.
+#
+# Download: https://github.com/robwierzbowski/jekyll-image-tag
+# Documentation: https://github.com/robwierzbowski/jekyll-image-tag/readme.md
+# Issues: https://github.com/robwierzbowski/jekyll-image-tag/issues
+#
+# Syntax:  {% image [preset or WxH] path/to/img.jpg [attr="value"] %}
+# Example: {% image poster.jpg alt="The strange case of Dr. Jekyll" %}
+#          {% image gallery poster.jpg alt="The strange case of Dr. Jekyll" class="gal-img" data-selected %}
+#          {% image 350xAUTO poster.jpg alt="The strange case of Dr. Jekyll" class="gal-img" data-selected %}
+#
+# See the documentation for full configuration and usage instructions.
+
+require 'fileutils'
+require 'pathname'
+require 'digest/md5'
+require 'mini_magick'
+
+module Jekyll
+
+  class Image < Liquid::Tag
+
+    def initialize(tag_name, markup, tokens)
+      @markup = markup
+      super
+    end
+
+    def render(context)
+
+      # Render any liquid variables in tag arguments and unescape template code
+      render_markup = Liquid::Template.parse(@markup).render(context).gsub(/\\\{\\\{|\\\{\\%/, '\{\{' => '{{', '\{\%' => '{%')
+
+      # Gather settings
+      site = context.registers[:site]
+      settings = site.config['image']
+      markup = /^(?:(?<preset>[^\s.:\/]+)\s+)?(?<image_src>[^\s]+\.[a-zA-Z0-9]{3,4})\s*(?<html_attr>[\s\S]+)?$/.match(render_markup)
+      preset = settings['presets'][ markup[:preset] ]
+
+      raise "Image Tag can't read this tag. Try {% image [preset or WxH] path/to/img.jpg [attr=\"value\"] %}." unless markup
+
+      # Assign defaults
+      settings['source'] ||= '.'
+      settings['output'] ||= 'generated'
+
+      # Prevent Jekyll from erasing our generated files
+      site.config['keep_files'] << settings['output'] unless site.config['keep_files'].include?(settings['output'])
+
+      # Process instance
+      instance = if preset
+        {
+          :width => preset['width'],
+          :height => preset['height'],
+          :src => markup[:image_src]
+        }
+      elsif dim = /^(?:(?<width>\d+)|auto)(?:x)(?:(?<height>\d+)|auto)$/i.match(markup[:preset])
+        {
+          :width => dim['width'],
+          :height => dim['height'],
+          :src => markup[:image_src]
+        }
+      else
+        { :src => markup[:image_src] }
+      end
+
+      # Process html attributes
+      html_attr = if markup[:html_attr]
+        Hash[ *markup[:html_attr].scan(/(?<attr>[^\s="]+)(?:="(?<value>[^"]+)")?\s?/).flatten ]
+      else
+        {}
+      end
+
+      if preset && preset['attr']
+        html_attr = preset['attr'].merge(html_attr)
+      end
+
+      html_attr_string = html_attr.inject('') { |string, attrs|
+        if attrs[1]
+          string << "#{attrs[0]}=\"#{attrs[1]}\" "
+        else
+          string << "#{attrs[0]} "
+        end
+      }
+
+      # Raise some exceptions before we start expensive processing
+      raise "Image Tag can't find the \"#{markup[:preset]}\" preset. Check image: presets in _config.yml for a list of presets." unless preset || dim ||  markup[:preset].nil?
+
+      # Generate resized images
+      generated_src = generate_image(instance, site.source, site.dest, settings['source'], settings['output'])
+      unless generated_src
+        return
+      end
+
+      generated_src = File.join(site.baseurl, generated_src) unless site.baseurl.empty?
+      # Return the markup!
+      "<img src=\"#{generated_src}\" #{html_attr_string}>"
+    end
+
+    def generate_image(instance, site_source, site_dest, image_source, image_dest)
+
+      image_source_path = File.join(site_source, image_source, instance[:src])
+      unless File.exists?image_source_path
+        puts "Missing: #{image_source_path}"
+        return false
+      end
+
+      image = MiniMagick::Image.open(image_source_path)
+      image.coalesce
+      digest = Digest::MD5.hexdigest(image.to_blob).slice!(0..5)
+
+      image_dir = File.dirname(instance[:src])
+      ext = File.extname(instance[:src])
+      basename = File.basename(instance[:src], ext)
+
+      orig_width = image[:width].to_f
+      orig_height = image[:height].to_f
+      orig_ratio = orig_width/orig_height
+
+      gen_width = if instance[:width]
+        instance[:width].to_f
+      elsif instance[:height]
+        orig_ratio * instance[:height].to_f
+      else
+        orig_width
+      end
+      gen_height = if instance[:height]
+        instance[:height].to_f
+      elsif instance[:width]
+        instance[:width].to_f / orig_ratio
+      else
+        orig_height
+      end
+      gen_ratio = gen_width/gen_height
+
+      # Don't allow upscaling. If the image is smaller than the requested dimensions, recalculate.
+      if orig_width < gen_width || orig_height < gen_height
+        undersize = true
+        gen_width = if orig_ratio < gen_ratio then orig_width else orig_height * gen_ratio end
+        gen_height = if orig_ratio > gen_ratio then orig_height else orig_width/gen_ratio end
+      end
+
+      gen_name = "#{basename}-#{gen_width.round}x#{gen_height.round}-#{digest}#{ext}"
+      gen_dest_dir = File.join(site_dest, image_dest, image_dir)
+      gen_dest_file = File.join(gen_dest_dir, gen_name)
+
+      # Generate resized files
+      unless File.exists?(gen_dest_file)
+
+        warn "Warning:".yellow + " #{instance[:src]} is smaller than the requested output file. It will be resized without upscaling." if undersize
+
+        #  If the destination directory doesn't exist, create it
+        FileUtils.mkdir_p(gen_dest_dir) unless File.exist?(gen_dest_dir)
+
+        # Let people know their images are being generated
+        puts "Generating #{gen_name}"
+
+        # Scale and crop
+        image.combine_options do |i|
+          i.resize "#{gen_width}x#{gen_height}^"
+          i.gravity "center"
+          i.crop "#{gen_width}x#{gen_height}+0+0"
+          i.layers "Optimize"
+        end
+
+        image.write gen_dest_file
+      end
+
+      # Return path relative to the site root for html
+      Pathname.new(File.join('/', image_dest, image_dir, gen_name)).cleanpath
+    end
+  end
+end
+
+Liquid::Template.register_tag('image', Jekyll::Image)

--- a/_plugins/image_tag.rb
+++ b/_plugins/image_tag.rb
@@ -107,7 +107,6 @@ module Jekyll
       end
 
       image = MiniMagick::Image.open(image_source_path)
-      image.coalesce
       digest = Digest::MD5.hexdigest(image.to_blob).slice!(0..5)
 
       image_dir = File.dirname(instance[:src])

--- a/_plugins/image_tag.rb
+++ b/_plugins/image_tag.rb
@@ -161,7 +161,6 @@ module Jekyll
           i.resize "#{gen_width}x#{gen_height}^"
           i.gravity "center"
           i.crop "#{gen_width}x#{gen_height}+0+0"
-          i.layers "Optimize"
         end
 
         image.write gen_dest_file

--- a/_plugins/image_tag.rb
+++ b/_plugins/image_tag.rb
@@ -158,6 +158,7 @@ module Jekyll
 
         # Scale and crop
         image.combine_options do |i|
+          i.quality(80)
           i.resize "#{gen_width}x#{gen_height}^"
           i.gravity "center"
           i.crop "#{gen_width}x#{gen_height}+0+0"

--- a/_posts/2018-11-15-cafesand.md
+++ b/_posts/2018-11-15-cafesand.md
@@ -5,21 +5,21 @@ author: Louis
 date:   2018-11-17 00:19:00 +0200
 ---
 
-<img src="/blog/files/2018-11-15/cafe_sand_beleuchtet.jpg" style="max-height:400px">
+{% image AUTOx800 blog/files/2018-11-15/cafe_sand_beleuchtet.jpg style="max-height:400px" alt="Beleuchtetes Café Sand" %}
 Mitten im Herzen Bremens direkt an der Weser: dort und in der Umgebung gibt es ab jetzt Freifunk-WLAN. In den letzten Sommerwochen haben wir es in vielen kleinen Aktionen aufgebaut und getestet.
 
 ## Richtfunk statt Kabel
 Das erste Problem: so wirklich schnelles Internet gibt es an diesem Ort - eigentlich - generell nicht. Die Begründung der Internetanbieter: zu alte Leitungen.
 Doch dank LWLcom konnte das überwunden werden. Abseits vom erdverbuddelten Kabelsystem haben sie uns mit einer Richtfunkverbindung mit dem Rest der Welt verbunden.
 Im ersten Schritt wird dort nun das Café Sand mit freiem Freifunk-WLAN versorgt.
-<a href="/blog/files/2018-11-15/clients_grafana.png"><img src="/blog/files/2018-11-15/clients_grafana.png" alt="unify ist gut belegt" style="max-height:400px"></a>
+{% image AUTOx800 blog/files/2018-11-15/clients_grafana.png style="max-height:400px" alt="Unify ist gut belegt" %}
 
 ## Die Parzellisten
 Aber nicht nur direkt vor Ort können die Besucher des Café Sands das Netz nutzen, sondern auch in angrenzenden Gebieten.
 Wir haben Vorkehrungen getroffen, die auch Kleingärtner profitieren lassen:  
 Durch die Installation am Café Sand können sich die Parzellisten auf dem Stadtwerder (ähnlich wie bei Satellitenfernsehen) einen kostenlosen Freifunk-Zugang mit Internet einrichten.
 Dazu müssen lediglich einmalig die [passenden Geräte](https://wiki.bremen.freifunk.net/Anleitungen/Firmware/Flashen#auswahl-der-hardware_richtfunk-f%C3%BCr-den-au%C3%9Fenbereich) gekauft und eingerichtet werden.
-<a href="/blog/files/2018-11-15/cafesand_braungruen.png"><img src="/blog/files/2018-11-15/cafesand_braungruen.png" alt="screenshot1" style="max-height:400px"></a>
+{% image AUTOx800 blog/files/2018-11-15/cafesand_braungruen.png style="max-height:400px" alt="Karte mit Mesh-Verbindungen" %}
 
 ## Der Osterdeich
 Aber auch auf der Nordseite der Weser haben wir jetzt einen Punkt, an dem sich andere Freifunk-Router verbinden können: das Fährhäuschen.

--- a/_posts/2018-11-22-Buergerpreis.md
+++ b/_posts/2018-11-22-Buergerpreis.md
@@ -5,9 +5,7 @@ author: genofire
 date:   2018-12-05 17:29:00 +0200
 ---
 
-<center>
-	<img src="/blog/files/2018-11-22/urkunde.jpg" alt="Die Urkunde des Bürgerpreises" style="width:400px" />
-</center>
+{% image 800xAUTO blog/files/2018-11-22/urkunde.jpg width="400" alt="Die Urkunde des Bürgerpreises" %}
 
 Dieses Jahr ist Freifunk Bremen einer der sieben Gewinner des Bürgerpreises der Sparkasse Bremen in der Kategorie "Alltagshelden".
 Wir bedanken uns herzlich für die Anerkennung unserer ehrenamtlichen Arbeit.

--- a/_posts/2018-12-09-Rueckblick-auf-die-Breminale-2018.md
+++ b/_posts/2018-12-09-Rueckblick-auf-die-Breminale-2018.md
@@ -28,7 +28,7 @@ Neu in diesem Jahr war ein übergroßer (länger als 4 m) ausgedruckter Veransta
 Ausnahmsweise galt: Analog for the win. Auf ihm konnten wir in ausgezeichneter Größe die Position unserer 
 Hardware markieren. Das hat gut geholfen, um auch Personen
 einen Überblick über das Netz zu geben, die nicht von Anfang an dabei waren.
-<a href="/blog/files/2018-11-30/breminale_plan.jpg"><img src="/blog/files/2018-11-30/breminale_plan.jpg" alt="Plan mit Menschen, die darauf Zeigen" style="max-height:400px"></a>
+{% image AUTOx800 blog/files/2018-11-30/breminale_plan.jpg style="max-height:400px" alt="Plan mit Menschen, die darauf zeigen" %}
 
 ## Der Versuch
 Neben dem Anspruch, tausende Besucher mit Internet per WLAN zu versorgen ist die Breminale für uns auch eine Spielwiese.
@@ -43,7 +43,7 @@ die bisherige Software-Technik verwendet worden.
 Während der Breminale lief das Netz nicht kontinuierlich stabil. Wenn es lief, waren Geschwindigkeiten von 80 MBit/s
 der Durchschnitt. Die Probleme, die zeitweise zum Ausfall des Netzes führten, sind nicht alle eindeutig
 identifiziert.
-<a href="/blog/files/2018-11-30/breminale_map.jpg"><img src="/blog/files/2018-11-30/breminale_map.jpg" alt="Stadtplan, auf dem Routerstandorte markiert sind" style="max-height:400px"></a>
+{% image AUTOx800 blog/files/2018-11-30/breminale_map.jpg style="max-height:400px" alt="Stadtplan, auf dem Routerstandorte markiert sind" %}
 
 
 ## Die Stimmung


### PR DESCRIPTION
Hier ist ein Ansatz, mit [jekyll-image-tag](https://github.com/robwierzbowski/jekyll-image-tag) die Bilder in Blogposts automatisch zu skalieren. Das wäre eine mögliche Lösung für #65. In den zwei neuesten Blogposts hab ich das mal angewandt.

Vorteile von jekyll-image-tag:
- es funktioniert
- es lässt sich auf dem Webserver vermutlich problemlos installieren (imagemagick muss aber noch installiert werden)

Nachteile:
- wird nicht mehr gewartet
- erzeugt keine "Responsive Images" (also verschiedene Auflösungen für verschiedene Bildschirmgrößen), sondern erzeugt nur eine einzige Variante pro Bild.