### PR TITLE
Blogpost "Neue Testing-Version 2018.2.2+bremen1" hinzugefügt

### DIFF
--- a/_posts/2019-07-27-Neue-Testing.md
+++ b/_posts/2019-07-27-Neue-Testing.md
@@ -7,6 +7,6 @@ date:   2019-07-27 14:37:51 +0200
 
 Nach langer Zeit gibt es endlich wieder eine neue Testing-Firmware für das Bremer Freifunk-Netz. Die Version [2018.2.2+bremen1](https://downloads.bremen.freifunk.net/firmware/all/2018.2.2+bremen1/) wird ab heute an alle Knoten verteilt, bei denen automatische Updates auf Testing-Versionen eingeschaltet sind.
 
-Die wichtigsten Änderungen in dieser Version dürften Fehlerbehebungen für Sicherheitslücken sein, durch die ein Knoten aus der Ferne zu einem Neustart gebracht werden könnte. Außerdem wurden Fehler im Zusammenhang mit der Statusseite und mit der Zählung der Clients behoben.
+Mit dieser Version sind wir wieder auf dem neuesten Stand der [Gluon-Entwicklung](https://gluon.readthedocs.io/en/v2018.2.x/). Die wichtigsten Änderungen dürften Fehlerbehebungen für Sicherheitslücken sein, durch die ein Knoten aus der Ferne zu einem Neustart gebracht werden könnte. Außerdem wurden Fehler im Zusammenhang mit der Statusseite und mit der Zählung der Clients behoben.
 
 Mehr Infos zu der neuen Version stehen wie üblich auf der [Changelog-Seite im Wiki](https://wiki.ffhb.de/Firmware/Changelog#freifunk-bremen-versionen_2018-2-2-bremen1).

--- a/_posts/2019-07-27-Neue-Testing.md
+++ b/_posts/2019-07-27-Neue-Testing.md
@@ -1,0 +1,12 @@
+---
+layout: post
+title:  "Neue Testing-Version 2018.2.2+bremen1"
+author: oliver
+date:   2019-07-27 14:37:51 +0200
+---
+
+Nach langer Zeit gibt es endlich wieder eine neue Testing-Firmware für das Bremer Freifunk-Netz. Die Version [2018.2.2+bremen1](https://downloads.bremen.freifunk.net/firmware/all/2018.2.2+bremen1/) wird ab heute an alle Knoten verteilt, bei denen automatische Updates auf Testing-Versionen eingeschaltet sind.
+
+Die wichtigsten Änderungen in dieser Version dürften Fehlerbehebungen für Sicherheitslücken sein, durch die ein Knoten aus der Ferne zu einem Neustart gebracht werden könnte. Außerdem wurden Fehler im Zusammenhang mit der Statusseite und mit der Zählung der Clients behoben.
+
+Mehr Infos zu der neuen Version stehen wie üblich auf der [Changelog-Seite im Wiki](https://wiki.ffhb.de/Firmware/Changelog#freifunk-bremen-versionen_2018-2-2-bremen1).


### PR DESCRIPTION
Schaut den Text mal bitte an, damit ich das heute Nachmittag online stellen kann; danach würde ich dann die neue Testing freischalten.