### PR TITLE
2020-01-18 Neue Stable

### DIFF
--- a/_posts/2020-01-17-neue-stable.md
+++ b/_posts/2020-01-17-neue-stable.md
@@ -4,18 +4,18 @@ title:  "2019.1+bremen1 als neue stable Version"
 author: Timlukas
 date:   2020-01-18 18:00:00 +0200
 ---
-Auf dem gestrigen Treffen haben wir die aktuelle testing Firmware [2019.1+bremen1](https://wiki.bremen.freifunk.net/Firmware/Changelog#freifunk-bremen-versionen_2019-1-bremen1) zur neuen stable erklärt.
-Diese war bereits seit dem 14.10.2019 als testing im Einsatz und hat seitdem keine Probleme bereitet, sodass wir diese nun guten Gewissens freigeben können.
+Auf dem gestrigen Freifunk-Treffen haben wir die aktuelle "testing"-Firmware [2019.1+bremen1](https://wiki.bremen.freifunk.net/Firmware/Changelog#freifunk-bremen-versionen_2019-1-bremen1) zur neuen "stable"-Version erklärt.
+Die Firmware war bereits seit dem 14.10.2019 als testing im Einsatz und hat seitdem keine Probleme bereitet, sodass wir diese nun guten Gewissens freigeben können.
 
 Mit dieser Version wird jetzt der D-Link DAP-1330 A1 als neues Gerät unterstützt.
 
-Außerdem erhöhen wir unsere Versionsnummer damit auf 2019 und werden die aktuelle testing los, damit in den nächsten Tagen eine neue testing-Version erscheinen kann, welche dann die Umstellung auf einen neuen WLAN-Standard zum meshen beinhalten wird.
-Dazu folgt in nächster Zeit noch ein weiterer Blog-Post.
+Außerdem erhöhen wir unsere Versionsnummer damit auf 2019 und werden die aktuelle testing los, damit in den nächsten Tagen eine neue testing-Version erscheinen kann, welche die Umstellung auf einen neuen WLAN-Standard beinhalten wird. Diese Umstellung ist nur für das Meshen der Freifunk-Geräte relevant, als Nutzer betrifft einen diese Änderung nicht.
+Zu der Umstellung folgt in nächster Zeit ein weiterer Blog-Post.
 
-Das Upgrade wird in den kommenden sieben Tagen automatisch auf alle Knoten im Bremer Freifunk-Netz verteilt,
+Das Upgrade wird in den kommenden sieben Tagen automatisch auf allen Knoten im Bremer Freifunk-Netz installiert,
 auf denen automatische Upgrades für die Stable-Version aktiviert sind.
 Das sind etwa 90% aller Knoten.
-Wer das automatische Upgrade ausgeschaltet hat, findet die Firmware für ein manuelles Upgrade auch auf [downloads.bremen.freifunk.net](https://downloads.bremen.freifunk.net/firmware/all/2019.1+bremen1/).
+Wer das automatische Upgrade deaktiviert hat, findet die Firmware für ein manuelles Upgrade auch auf [downloads.bremen.freifunk.net](https://downloads.bremen.freifunk.net/firmware/all/2019.1+bremen1/).
 
 ## Feedback
 

--- a/_posts/2020-01-17-neue-stable.md
+++ b/_posts/2020-01-17-neue-stable.md
@@ -1,0 +1,25 @@
+---
+layout: post
+title:  "2019.1+bremen1 als neue stable Version"
+author: Timlukas
+date:   2020-01-18 18:00:00 +0200
+---
+Auf dem gestrigen Treffen haben wir die aktuelle testing Firmware [2019.1+bremen1](https://wiki.bremen.freifunk.net/Firmware/Changelog#freifunk-bremen-versionen_2019-1-bremen1) zur neuen stable erklärt.
+Diese war bereits seit dem 14.10.2019 als testing im Einsatz und hat seitdem keine Probleme bereitet, sodass wir diese nun guten Gewissens freigeben können.
+
+Mit dieser Version wird jetzt der D-Link DAP-1330 A1 als neues Gerät unterstützt.
+
+Außerdem erhöhen wir unsere Versionsnummer damit auf 2019 und werden die aktuelle testing los, damit in den nächsten Tagen eine neue testing-Version erscheinen kann, welche dann die Umstellung auf einen neuen WLAN-Standard zum meshen beinhalten wird.
+Dazu folgt in nächster Zeit noch ein weiterer Blog-Post.
+
+Das Upgrade wird in den kommenden sieben Tagen automatisch auf alle Knoten im Bremer Freifunk-Netz verteilt,
+auf denen automatische Upgrades für die Stable-Version aktiviert sind.
+Das sind etwa 90% aller Knoten.
+Wer das automatische Upgrade ausgeschaltet hat, findet die Firmware für ein manuelles Upgrade auch auf [downloads.bremen.freifunk.net](https://downloads.bremen.freifunk.net/firmware/all/2019.1+bremen1/).
+
+## Feedback
+
+Falls ihr Probleme mit der neuen Firmware bemerkt oder Fragen habt,
+schreibt auf der [Mailingliste](https://lists.bremen.freifunk.net/mailman/listinfo/ff-bremen/),
+kommt zum [Treffen](/kontakt.html#treffen),
+oder tauscht euch im [Chat](https://webirc.hackint.org/#ircs://irc.hackint.org/#ffhb?nick=Gast_?) mit uns aus.

--- a/_posts/2020-01-17-neue-stable.md
+++ b/_posts/2020-01-17-neue-stable.md
@@ -9,7 +9,7 @@ Die Firmware war bereits seit dem 14.10.2019 als testing im Einsatz und hat seit
 
 Mit dieser Version wird jetzt der D-Link DAP-1330 A1 als neues Gerät unterstützt.
 
-Außerdem erhöhen wir unsere Versionsnummer damit auf 2019 und werden die aktuelle testing los, damit in den nächsten Tagen eine neue testing-Version erscheinen kann, welche die Umstellung auf einen neuen WLAN-Standard beinhalten wird. Diese Umstellung ist nur für das Meshen der Freifunk-Geräte relevant, als Nutzer betrifft einen diese Änderung nicht.
+Außerdem erhöhen wir unsere Versionsnummer damit auf 2019 und werden die aktuelle testing los, damit in den nächsten Tagen eine neue testing-Version erscheinen kann, welche die Umstellung auf einen neuen WLAN-Standard beinhalten wird. Diese Umstellung ist nur für das Meshen der Freifunk-Geräte per WLAN relevant, als Nutzer betrifft einen diese Änderung nicht.
 Zu der Umstellung folgt in nächster Zeit ein weiterer Blog-Post.
 
 Das Upgrade wird in den kommenden sieben Tagen automatisch auf allen Knoten im Bremer Freifunk-Netz installiert,

--- a/_posts/2020-01-18-neue-stable.md
+++ b/_posts/2020-01-18-neue-stable.md
@@ -5,15 +5,15 @@ author: Timlukas
 date:   2020-01-18 18:00:00 +0200
 ---
 Auf dem gestrigen Freifunk-Treffen haben wir die aktuelle "testing"-Firmware [2019.1+bremen1](https://wiki.bremen.freifunk.net/Firmware/Changelog#freifunk-bremen-versionen_2019-1-bremen1) zur neuen "stable"-Version erklärt.
-Die Firmware war bereits seit dem 14.10.2019 als testing im Einsatz und hat seitdem keine Probleme bereitet, sodass wir diese nun guten Gewissens freigeben können.
+Die Firmware war bereits seit dem 14.10.2019 als "testing" im Einsatz und hat seitdem keine Probleme bereitet, sodass wir diese nun guten Gewissens freigeben können.
 
 Mit dieser Version wird jetzt der D-Link DAP-1330 A1 als neues Gerät unterstützt.
 
-Außerdem erhöhen wir unsere Versionsnummer damit auf 2019 und werden die aktuelle testing los, damit in den nächsten Tagen eine neue testing-Version erscheinen kann, welche die Umstellung auf einen neuen WLAN-Standard beinhalten wird. Diese Umstellung ist nur für das Meshen der Freifunk-Geräte per WLAN relevant, als Nutzer betrifft einen diese Änderung nicht.
+Außerdem erhöhen wir unsere Versionsnummer damit auf "2019" und werden die aktuelle "testing"-Version los, damit in den nächsten Tagen eine neue erscheinen kann, welche die Umstellung auf einen neuen WLAN-Standard beinhalten wird. Diese Umstellung ist nur für das Meshen der Freifunk-Geräte per WLAN relevant, als Nutzer betrifft einen diese Änderung nicht.
 Zu der Umstellung folgt in nächster Zeit ein weiterer Blog-Post.
 
 Das Upgrade wird in den kommenden sieben Tagen automatisch auf allen Knoten im Bremer Freifunk-Netz installiert,
-auf denen automatische Upgrades für die Stable-Version aktiviert sind.
+auf denen automatische Upgrades für die "stable"-Version aktiviert sind.
 Das sind etwa 90% aller Knoten.
 Wer das automatische Upgrade deaktiviert hat, findet die Firmware für ein manuelles Upgrade auch auf [downloads.bremen.freifunk.net](https://downloads.bremen.freifunk.net/firmware/all/2019.1+bremen1/).
 


### PR DESCRIPTION
Blogpost zur neuen stable Version 2019.1+bremen1, wie heute beim Treffen entschieden. Kann online gehen, sobald die stable online ist.