### PR TITLE
[POST] 2020-01-20 Wechsel von ibss zu 11s

### DIFF
--- a/_posts/2020-01-20-wechsel_von_ibss_zu_11s.md
+++ b/_posts/2020-01-20-wechsel_von_ibss_zu_11s.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title:  "Wechsel von ibss zu 11s (2019.1+bremen1.1 als neue Testing-Version)"
+title:  "Wechsel von IBSS zu 11s (2019.1+bremen1.1 als neue Testing-Version)"
 author: genofire
 date:   2020-01-20 18:00:00 +0200
 ---
@@ -9,10 +9,10 @@ Mit der aktuellen Testing 2019.1.1-bremen1 wollen wir auch eine Umstellung im WL
 
 Als die Bremer Freifunk Initiative zu existieren begann haben wir das WLAN-Meshing mittels IBSS-Standard umgesetzt.
 Gleichzeitig wurde mit [802.11s](https://de.wikipedia.org/wiki/IEEE_802.11s) ein neuerer Standard für Meshing im WLAN entwickelt und ist über die letzten zehn Jahre in den meisten WLAN-Chips der Router implementiert worden.
-Dies führt dazu, dass die Router-Modelle aktuell öfters 11s als ibss unterstützen.
+Dies führt dazu, dass die neuren Router-Modelle 11s öfter als IBSS unterstützen.
 
 Zusammengefasst bringt uns der Wechsel von IBSS auf 11s für die Zukunft weitere Router-Modelle (unter anderem ein paar AVM-Fritzboxen).
-Zudem ist der Wechsel notwendig, da [Gluon](https://wiki.freifunk.net/Gluon), das verwendete Basis der Bremer Freifunk-Firmware, ebenfalls plant, kein IBSS mehr zu unterstützen.
+Zudem ist der Wechsel notwendig, da [Gluon](https://wiki.freifunk.net/Gluon), die verwendete Basis der Bremer Freifunk-Firmware, ebenfalls plant, kein IBSS mehr zu unterstützen.
 
 Die **Umsetzung** ist relativ komplex und wird mit viel Testerei (voraussichtlich) am 05.03.2020 auf allen Routern nahezu gleichzeitig durchgeführt.
 Um einige Tests vor der Beförderung zur Stable-Version durchführen zu können, veröffentlichen wir die Firmware zunächst als Testing-Version. 
@@ -20,7 +20,7 @@ Um einige Tests vor der Beförderung zur Stable-Version durchführen zu können,
 Falls ihr die Firmware bereits jetzt ausprobieren wollt, ändert einfach die Domain im Config-Modus oder per SSH:
 `uci set gluon.core.domain='ffhb_11s' && gluon-reconfigure && gluon-reload`.
 Denkt bitte daran, dass ihr die Umstellung in euerem kompletten WLAN-Mesh macht, damit sich die Geräte untereinander wieder verbinden können.
-Euer Feedback ist gern gesehen, entweder bei einem der nächsten Freifunk-Treffen oder per Mail.
+Euer Feedback ist ausdrücklich erwünscht, entweder bei einem der nächsten Freifunk-Treffen, per Mail, bei Facebook, Twitter, Instagramm oder im Chat.
 
 Wir hoffen, dass die Testläufe gut gelingen und viele Erfahrungen gesammelt werden, die bei komplexen Mesh-Änderungen genutzt werden können.
 

--- a/_posts/2020-01-20-wechsel_von_ibss_zu_11s.md
+++ b/_posts/2020-01-20-wechsel_von_ibss_zu_11s.md
@@ -7,20 +7,23 @@ date:   2020-01-20 18:00:00 +0200
 
 Mit der aktuellen Testing 2019.1.1-bremen1 wollen wir auch eine Umstellung im WLAN-Meshen angehen.
 
-Wir haben mit Freifunk vor Jahren angefangen und damals das WLAN-Meshing mittels ibss umgesetzt.
-Gleichzeitig wurde mit [802.11s](https://de.wikipedia.org/wiki/IEEE_802.11s) ein Standard für Meshing im WLAN entwickelt und ist über die letzten zehn Jahre in den meisten WLAN-Chips der Router implementiert worden.
-Dies führt dazu, dass die Router-Modelle nun öfters 11s als ibss unterstützen.
+Als die Bremer Freifunk Initiative zu existieren begann haben wir das WLAN-Meshing mittels IBSS-Standard umgesetzt.
+Gleichzeitig wurde mit [802.11s](https://de.wikipedia.org/wiki/IEEE_802.11s) ein neuerer Standard für Meshing im WLAN entwickelt und ist über die letzten zehn Jahre in den meisten WLAN-Chips der Router implementiert worden.
+Dies führt dazu, dass die Router-Modelle aktuell öfters 11s als ibss unterstützen.
 
 Zusammengefasst bringt uns der Wechsel von IBSS auf 11s für die Zukunft weitere Router-Modelle (unter anderem ein paar AVM-Fritzboxen).
-Zudem ist der Wechsel notwendig, da [Gluon](https://wiki.freifunk.net/Gluon), das verwendete Firmware-Framework, ebenfalls plant, kein ibss mehr zu unterstützen.
+Zudem ist der Wechsel notwendig, da [Gluon](https://wiki.freifunk.net/Gluon), das verwendete Basis der Bremer Freifunk-Firmware, ebenfalls plant, kein IBSS mehr zu unterstützen.
 
-Die **Umsetzung** ist relativ komplex und wird mit viel Testerei dann zum 05.03.2020 auf allen Routern nahezu gleichzeitig durchgeführt.
-Dieses ist Teil der neuesten Testing-Firmware, welche hoffentlich rechtzeitig vorher zur Stable-Version wird.
+Die **Umsetzung** ist relativ komplex und wird mit viel Testerei (voraussichtlich) am 05.03.2020 auf allen Routern nahezu gleichzeitig durchgeführt.
+Um einige Tests vor der Beförderung zur Stable-Version durchführen zu können, veröffentlichen wir die Firmware zunächst als Testing-Version. 
 
-Falls ihr dies bereits jetzt ausprobieren wollt, ändert einfach die Domain im Config-Modus oder per SSH
+Falls ihr die Firmware bereits jetzt ausprobieren wollt, ändert einfach die Domain im Config-Modus oder per SSH:
 `uci set gluon.core.domain='ffhb_11s' && gluon-reconfigure && gluon-reload`.
-Doch denkt dran, dass ihr dies in euerem kompletten WLAN-Mesh macht, damit sich die Geräte untereinander wieder verbinden.
+Denkt bitte daran, dass ihr die Umstellung in euerem kompletten WLAN-Mesh macht, damit sich die Geräte untereinander wieder verbinden können.
+Euer Feedback ist gern gesehen, entweder bei einem der nächsten Freifunk-Treffen oder per Mail.
 
-Wir hoffen, dass dies gut gelingt und als Testlauf für komplexe Mesh-Änderungen genutzt werden kann.
-Denn sobald wir passende Server-Infrastruktur aufgebaut haben,
- wollen wir auf die gleiche Weise das ganze Protokoll zum Meshen (nicht nur für WLAN-Mesh-Verbindungen) von [B.A.T.M.A.N.](https://www.open-mesh.org/projects/open-mesh/wiki) IV zu B.A.T.M.A.N. V updaten.
+Wir hoffen, dass die Testläufe gut gelingen und viele Erfahrungen gesammelt werden, die bei komplexen Mesh-Änderungen genutzt werden können.
+
+Sobald das Update auf 11s eingespielt ist, beginnen die Vorbereitungen für eine noch weitreichendere Neuerung: 
+Das Update von [B.A.T.M.A.N.](https://www.open-mesh.org/projects/open-mesh/wiki) IV zu B.A.T.M.A.N. V .
+Dazu wird zunächst die Server-Infrastruktur aufgebaut und dann das Vorgehen beim aktuellen Update wiederholt.

--- a/_posts/2020-01-20-wechsel_von_ibss_zu_11s.md
+++ b/_posts/2020-01-20-wechsel_von_ibss_zu_11s.md
@@ -2,14 +2,14 @@
 layout: post
 title:  "Wechsel von IBSS zu 11s (2019.1+bremen1.1 als neue Testing-Version)"
 author: genofire
-date:   2020-01-20 18:00:00 +0200
+date:   2020-01-23 21:43:00 +0200
 ---
 
 Mit der aktuellen Testing 2019.1.1-bremen1 wollen wir auch eine Umstellung im WLAN-Meshen angehen.
 
-Als die Bremer Freifunk Initiative zu existieren begann haben wir das WLAN-Meshing mittels IBSS-Standard umgesetzt.
+Als die Bremer Freifunk Initiative zu existieren begann, haben wir das WLAN-Meshing mittels IBSS-Standard umgesetzt.
 Gleichzeitig wurde mit [802.11s](https://de.wikipedia.org/wiki/IEEE_802.11s) ein neuerer Standard für Meshing im WLAN entwickelt und ist über die letzten zehn Jahre in den meisten WLAN-Chips der Router implementiert worden.
-Dies führt dazu, dass die neuren Router-Modelle 11s öfter als IBSS unterstützen.
+Dies führt dazu, dass die neueren Router-Modelle 11s öfter als IBSS unterstützen.
 
 Zusammengefasst bringt uns der Wechsel von IBSS auf 11s für die Zukunft weitere Router-Modelle (unter anderem ein paar AVM-Fritzboxen).
 Zudem ist der Wechsel notwendig, da [Gluon](https://wiki.freifunk.net/Gluon), die verwendete Basis der Bremer Freifunk-Firmware, ebenfalls plant, kein IBSS mehr zu unterstützen.
@@ -19,11 +19,11 @@ Um einige Tests vor der Beförderung zur Stable-Version durchführen zu können,
 
 Falls ihr 11s in der neuen Testing-Firmware bereits jetzt ausprobieren wollt, ändert einfach die Domain im Config-Modus oder per SSH:
 `uci set gluon.core.domain='ffhb_11s' && gluon-reconfigure && gluon-reload`.
-Denkt bitte daran, dass ihr die Umstellung in euerem kompletten WLAN-Mesh macht, damit sich die Geräte untereinander wieder verbinden können.
-Euer Feedback ist ausdrücklich erwünscht, entweder bei einem der nächsten Freifunk-Treffen, per Mail, bei Facebook, Twitter, Instagramm oder im Chat.
+Denkt bitte daran, dass ihr die Umstellung in eurem kompletten WLAN-Mesh macht, damit sich die Geräte untereinander wieder verbinden können.
+Euer Feedback ist ausdrücklich erwünscht, entweder bei einem der nächsten Freifunk-Treffen, per Mail, bei Facebook, Twitter, Instagram oder im Chat.
 
 Wir hoffen, dass die Testläufe gut gelingen und viele Erfahrungen gesammelt werden, die bei komplexen Mesh-Änderungen genutzt werden können.
 
 Sobald das Update auf 11s eingespielt ist, beginnen die Vorbereitungen für eine noch weitreichendere Neuerung: 
-Das Update von [B.A.T.M.A.N.](https://www.open-mesh.org/projects/open-mesh/wiki) IV zu B.A.T.M.A.N. V .
+das Update von [B.A.T.M.A.N.](https://www.open-mesh.org/projects/open-mesh/wiki) IV zu B.A.T.M.A.N. V .
 Dazu wird zunächst die Server-Infrastruktur aufgebaut und dann das Vorgehen beim aktuellen Update wiederholt.

--- a/_posts/2020-01-20-wechsel_von_ibss_zu_11s.md
+++ b/_posts/2020-01-20-wechsel_von_ibss_zu_11s.md
@@ -17,7 +17,7 @@ Zudem ist der Wechsel notwendig, da [Gluon](https://wiki.freifunk.net/Gluon), di
 Die **Umsetzung** ist relativ komplex und wird mit viel Testerei (voraussichtlich) am 05.03.2020 auf allen Routern nahezu gleichzeitig durchgeführt.
 Um einige Tests vor der Beförderung zur Stable-Version durchführen zu können, veröffentlichen wir die Firmware zunächst als Testing-Version. 
 
-Falls ihr die Firmware bereits jetzt ausprobieren wollt, ändert einfach die Domain im Config-Modus oder per SSH:
+Falls ihr 11s in der neuen Testing-Firmware bereits jetzt ausprobieren wollt, ändert einfach die Domain im Config-Modus oder per SSH:
 `uci set gluon.core.domain='ffhb_11s' && gluon-reconfigure && gluon-reload`.
 Denkt bitte daran, dass ihr die Umstellung in euerem kompletten WLAN-Mesh macht, damit sich die Geräte untereinander wieder verbinden können.
 Euer Feedback ist ausdrücklich erwünscht, entweder bei einem der nächsten Freifunk-Treffen, per Mail, bei Facebook, Twitter, Instagramm oder im Chat.

--- a/_posts/2020-01-20-wechsel_von_ibss_zu_11s.md
+++ b/_posts/2020-01-20-wechsel_von_ibss_zu_11s.md
@@ -18,6 +18,10 @@ Die **Umsetzung** ist relativ komplex und wird mit viel testen dann zum 05.03.20
 (Falls es bei dir nicht geklappt hat, komme doch gern zum 06.03.2020 zu unser Freifunk treffen.)
 Dieses ist Teil der nun testing, welche rechtzeitig vorher hoffentlich zur stabil wird.
 
+Falls ihr dies bereits jetzt ausprobieren wollt, ändert einfach die Domain im Config-Modus oder per SSH
+`uci set gluon.core.domain='ffhb_11s' && gluon-reconfigure && gluon-reload`.
+Doch denkt dran, dass ihr dies in euer komplettes WLAN-Mesh macht, damit sich die Geräte untereinander wieder verbinden.
+
 Wir hoffen, dass dies gut gelingt und als Testlauf für das komplette Protokoll zum Meshen genutzt werden können.
 Denn sobald wir passende Server Infrastruktur aufgebaut haben,
  wollen wir auf der gleichen Weise das ganze Protokoll zum Meshen (nicht nur WLAN-Mesh Verbindungen) von Batman IV zu Batman V updaten.

--- a/_posts/2020-01-20-wechsel_von_ibss_zu_11s.md
+++ b/_posts/2020-01-20-wechsel_von_ibss_zu_11s.md
@@ -1,0 +1,23 @@
+---
+layout: post
+title:  "Wechsel von ibss zu 11s (2019.1+bremen1.1 als neue testing Version)"
+author: genofire
+date:   2020-01-20 18:00:00 +0200
+---
+
+Mit der aktuellen Testing 2019.1.1-bremen1 wollen wir auch eine Umstellung im WLAN-Meshen angehen.
+
+Wir haben mit Freifunk vor Jahren angefangen und damals das WLAN-Meshing mittels ibss umgesetzt.
+Gleichzeitig wurde ein Standard für Meshing in WLAN entwickelt und ist über die letzten 10 Jahre in den meisten WLAN-Chips der Router implementiert.
+Dies führt dazu das die Router-Modelle nun öfters 11s als ibss unterstützen.
+
+Zusammengefasst bringt es uns für die Zukunft weitere Router-Modelle (unter anderem ein paar AVM-Fritzboxen).
+Zudem ist es notwendig, da Gluon das verwendet Firmware-Framework ebenfalls plant, kein ibss mehr zu unterstützen.
+
+Die **Umsetzung** ist relativ komplex und wird mit viel testen dann zum 05.03.2020 auf allen Routern nahezu gleichzeitig durchgeführt.
+(Falls es bei dir nicht geklappt hat, komme doch gern zum 06.03.2020 zu unser Freifunk treffen.)
+Dieses ist Teil der nun testing, welche rechtzeitig vorher hoffentlich zur stabil wird.
+
+Wir hoffen, dass dies gut gelingt und als Testlauf für das komplette Protokoll zum Meshen genutzt werden können.
+Denn sobald wir passende Server Infrastruktur aufgebaut haben,
+ wollen wir auf der gleichen Weise das ganze Protokoll zum Meshen (nicht nur WLAN-Mesh Verbindungen) von Batman IV zu Batman V updaten.

--- a/_posts/2020-01-20-wechsel_von_ibss_zu_11s.md
+++ b/_posts/2020-01-20-wechsel_von_ibss_zu_11s.md
@@ -1,6 +1,6 @@
 ---
 layout: post
-title:  "Wechsel von ibss zu 11s (2019.1+bremen1.1 als neue testing Version)"
+title:  "Wechsel von ibss zu 11s (2019.1+bremen1.1 als neue Testing-Version)"
 author: genofire
 date:   2020-01-20 18:00:00 +0200
 ---
@@ -8,20 +8,19 @@ date:   2020-01-20 18:00:00 +0200
 Mit der aktuellen Testing 2019.1.1-bremen1 wollen wir auch eine Umstellung im WLAN-Meshen angehen.
 
 Wir haben mit Freifunk vor Jahren angefangen und damals das WLAN-Meshing mittels ibss umgesetzt.
-Gleichzeitig wurde ein Standard für Meshing in WLAN entwickelt und ist über die letzten 10 Jahre in den meisten WLAN-Chips der Router implementiert.
-Dies führt dazu das die Router-Modelle nun öfters 11s als ibss unterstützen.
+Gleichzeitig wurde mit [802.11s](https://de.wikipedia.org/wiki/IEEE_802.11s) ein Standard für Meshing im WLAN entwickelt und ist über die letzten zehn Jahre in den meisten WLAN-Chips der Router implementiert worden.
+Dies führt dazu, dass die Router-Modelle nun öfters 11s als ibss unterstützen.
 
-Zusammengefasst bringt es uns für die Zukunft weitere Router-Modelle (unter anderem ein paar AVM-Fritzboxen).
-Zudem ist es notwendig, da Gluon das verwendet Firmware-Framework ebenfalls plant, kein ibss mehr zu unterstützen.
+Zusammengefasst bringt uns der Wechsel von IBSS auf 11s für die Zukunft weitere Router-Modelle (unter anderem ein paar AVM-Fritzboxen).
+Zudem ist der Wechsel notwendig, da [Gluon](https://wiki.freifunk.net/Gluon), das verwendete Firmware-Framework, ebenfalls plant, kein ibss mehr zu unterstützen.
 
-Die **Umsetzung** ist relativ komplex und wird mit viel testen dann zum 05.03.2020 auf allen Routern nahezu gleichzeitig durchgeführt.
-(Falls es bei dir nicht geklappt hat, komme doch gern zum 06.03.2020 zu unser Freifunk treffen.)
-Dieses ist Teil der nun testing, welche rechtzeitig vorher hoffentlich zur stabil wird.
+Die **Umsetzung** ist relativ komplex und wird mit viel Testerei dann zum 05.03.2020 auf allen Routern nahezu gleichzeitig durchgeführt.
+Dieses ist Teil der neuesten Testing-Firmware, welche hoffentlich rechtzeitig vorher zur Stable-Version wird.
 
 Falls ihr dies bereits jetzt ausprobieren wollt, ändert einfach die Domain im Config-Modus oder per SSH
 `uci set gluon.core.domain='ffhb_11s' && gluon-reconfigure && gluon-reload`.
-Doch denkt dran, dass ihr dies in euer komplettes WLAN-Mesh macht, damit sich die Geräte untereinander wieder verbinden.
+Doch denkt dran, dass ihr dies in euerem kompletten WLAN-Mesh macht, damit sich die Geräte untereinander wieder verbinden.
 
-Wir hoffen, dass dies gut gelingt und als Testlauf für das komplette Protokoll zum Meshen genutzt werden können.
-Denn sobald wir passende Server Infrastruktur aufgebaut haben,
- wollen wir auf der gleichen Weise das ganze Protokoll zum Meshen (nicht nur WLAN-Mesh Verbindungen) von Batman IV zu Batman V updaten.
+Wir hoffen, dass dies gut gelingt und als Testlauf für komplexe Mesh-Änderungen genutzt werden kann.
+Denn sobald wir passende Server-Infrastruktur aufgebaut haben,
+ wollen wir auf die gleiche Weise das ganze Protokoll zum Meshen (nicht nur für WLAN-Mesh-Verbindungen) von [B.A.T.M.A.N.](https://www.open-mesh.org/projects/open-mesh/wiki) IV zu B.A.T.M.A.N. V updaten.


### PR DESCRIPTION
[Preview](https://github.com/FreifunkBremen/bremen.freifunk.net/blob/11s/_posts/2020-01-20-wechsel_von_ibss_zu_11s.md)