### PR TITLE
replace *.ffhb.de links with *.bremen.freifunk.net

### DIFF
--- a/_posts/2015-06-28-Erste-stabile-Firmware.md
+++ b/_posts/2015-06-28-Erste-stabile-Firmware.md
@@ -38,7 +38,7 @@ Schließlich braucht es natürlich auch etwas Zeit, die Firmware zu bauen und fe
 ### Firmware-Workshop
 Um zumindest den Kreis der Personen die in der Lage wären, eine Firmware zu bauen und zu veröffentlichen, zu vergrößern, wollen wir demnächst einen "Firmware-Workshop" veranstalten. Ähnlich dem kürzlichen "Backbone-Treffen" (das übrigens auch eine Neuauflage erfahren soll) ist der Plan, allen Interessenten einen Einblick in die Struktur der Firmware und darein, wie man sie bearbeitet, baut und veröffentlicht, zu geben. Ein Termin steht leider noch nicht fest. Sowieso empfehlen wir aber allen, die sich für dieses und andere Freifunk-Themen verstärkt interessieren und dort mitreden möchten unsere [Mailingliste] zu abonnieren und die Protokolle der Treffen im [Wiki] zu lesen, falls sie es selbst nicht geschafft haben vorbei zu kommen. Denn Freifunk ist ja kein schlüsselfertiger Dienst, sondern soll zur Beschäftigung mit der Thematik offener Netzwerke anregen – technisch, organisatorisch und sozial.
 
-[Mailingliste]: https://lists.ffhb.de/mailman/listinfo/ff-bremen/
+[Mailingliste]: https://lists.bremen.freifunk.net/mailman/listinfo/ff-bremen/
 [Wiki]: https://wiki.bremen.freifunk.net
 
 ### Probleme?

--- a/_posts/2015-11-19-Statusseite.md
+++ b/_posts/2015-11-19-Statusseite.md
@@ -5,4 +5,4 @@ author: mortzu
 date:   2015-11-19 16:30:19 +0200
 ---
 
-Wir haben eine Statusseite, die den Zustand der VPN-Server darstellt. Diese findet ihr unter [status.ffhb.de](http://status.ffhb.de/).
+Wir haben eine Statusseite, die den Zustand der VPN-Server darstellt. Diese findet ihr unter [status.bremen.freifunk.net](https://status.bremen.freifunk.net/).

--- a/_posts/2016-10-10-Förderung-NDS.md
+++ b/_posts/2016-10-10-Förderung-NDS.md
@@ -11,7 +11,7 @@ Am Ende bleiben noch ca. 50.000€ über, welche ausschließlich in Form von Har
 Auch der Freifunk Bremen ist in Niedersachsen aktiv. Im Bremer Umland gibt es einige Nodes, z.B. in Hagen im Bremischen, in Nienburg/Weser und in Syke.
 Für diese und weitere Standorte in Niedersachsen können nun Router beantragt werden.
 
-Zitat des [verlinkten Protokolls](https://cloud.ffhb.de/index.php/s/YUtWymrHw6iZVFk):
+Zitat des [verlinkten Protokolls](https://cloud.bremen.freifunk.net/index.php/s/YUtWymrHw6iZVFk):
 
 > Bis zum Stichtag 14.10.2016 werden die Freifunk Communities ihre Anträge für die kostenlose Nutzung der beschafften WLAN-Router an das NETZ-Zentrum für innovative Technologie Osterholz GmbH (NETZ-Zentrum) in Osterholz-Scharmbeck einreichen. Mit dem Antrag sollten realistische Gerätezahlen gemeldet werden, wobei für die erste Planung eine ortsteilgenaue Angabe für die Planung zur Beantragung ausreichend ist, die später im Verwendungsnachweis durch die genauen Adressen der installierten Geräte ersetzt werden müssen.
 >
@@ -34,7 +34,7 @@ Es stehen folgende Modelle zur Verfügung:
 * Ubiquiti pbe-5ac-500
 
 Dazu gibt es noch ein
-[„Infoblatt zur kostenfreien aber zweckgebundenen Überlassung von WLAN-Routern“](https://cloud.ffhb.de/index.php/s/NduTBLKUADA5EVb):
+[„Infoblatt zur kostenfreien aber zweckgebundenen Überlassung von WLAN-Routern“](https://cloud.bremen.freifunk.net/index.php/s/NduTBLKUADA5EVb):
 
 1. Die Geräte sind ab Erhalt mindestens bis zum 31.12.2017 zweckgebunden zu nutzen.
 2. Die Geräte sind spätestens bis zum 28.02.2017 in Betrieb zu nehmen. Die Inbetriebnahme ist mit einem Screenshot (der Freifunk-Karte) und einer tabellarischen Auflistung der Adressen, an denen die WLAN-Router (mit Angabe ihrer Serien-Nr.) installiert wurden, nachzuweisen.
@@ -45,6 +45,6 @@ Dazu gibt es noch ein
 7. Überzählige und/oder nicht genutzte Geräte sind dem NETZ-Zentrum bis zum 31.12.2017 anzuzeigen und auf Verlangen des NETZ-Zentrums auf eigene Kosten entweder an dieses oder an eine zu benennende Freifunkinitiative zu versenden. Für nicht herausgegebene Geräte ist Wertersatz zu leisten.
 8. Die Einstellung des Betriebs der Freifunkinitiative ist dem NETZ-Zentrum bis zum 31.1.2017 anzuzeigen. Und es ist wie unter Punkt 7 zu verfahren."
 
-Das Formular zum Beantragen der Router gibt es [hier](https://cloud.ffhb.de/index.php/s/NduTBLKUADA5EVb).
+Das Formular zum Beantragen der Router gibt es [hier](https://cloud.bremen.freifunk.net/index.php/s/NduTBLKUADA5EVb).
 
 Info-Seiten des bzn gibt es [hier](http://www.breitband-niedersachsen.de/index.php?id=674) und [hier](http://www.breitband-niedersachsen.de/index.php?id=680).

--- a/_posts/2016-11-29-Statusseite-und-weiteres-Gatemon-in-Betrieb.md.md
+++ b/_posts/2016-11-29-Statusseite-und-weiteres-Gatemon-in-Betrieb.md.md
@@ -4,7 +4,7 @@ title:  "Statusseite und weiteres Gatemon in Betrieb"
 author: SimJoSt
 date:   2016-11-29 17:59:24 +0100
 ---
-Über den Lauf des Jahres haben wir ein System aufgebaut, welches die Funktion der Gateways (Server) von Freifunk Bremen regelmäßig testet. Die Ergebnisse dieser Tests werden auf unserer [Statusseite](https://status.ffhb.de/) angezeigt, welche wir bis jetzt nur intern genutzt haben.
+Über den Lauf des Jahres haben wir ein System aufgebaut, welches die Funktion der Gateways (Server) von Freifunk Bremen regelmäßig testet. Die Ergebnisse dieser Tests werden auf unserer [Statusseite](https://status.bremen.freifunk.net/) angezeigt, welche wir bis jetzt nur intern genutzt haben.
 
 ![Statusseite wenn alle Tests erfolgreich durchgelaufen sind](/blog/files/2016-11-29/statusseite.png)
 

--- a/_posts/2019-07-27-Neue-Testing.md
+++ b/_posts/2019-07-27-Neue-Testing.md
@@ -9,4 +9,4 @@ Nach langer Zeit gibt es endlich wieder eine neue Testing-Firmware für das Brem
 
 Mit dieser Version sind wir wieder auf dem neuesten Stand der [Gluon-Entwicklung](https://gluon.readthedocs.io/en/v2018.2.x/). Die wichtigsten Änderungen dürften Fehlerbehebungen für Sicherheitslücken sein, durch die ein Knoten aus der Ferne zu einem Neustart gebracht werden könnte. Außerdem wurden Fehler im Zusammenhang mit der Statusseite und mit der Zählung der Clients behoben.
 
-Mehr Infos zu der neuen Version stehen wie üblich auf der [Changelog-Seite im Wiki](https://wiki.ffhb.de/Firmware/Changelog#freifunk-bremen-versionen_2018-2-2-bremen1).
+Mehr Infos zu der neuen Version stehen wie üblich auf der [Changelog-Seite im Wiki](https://wiki.bremen.freifunk.net/Firmware/Changelog#freifunk-bremen-versionen_2018-2-2-bremen1).

--- a/_posts/2020-02-25-warnung_umstellung_11s.md
+++ b/_posts/2020-02-25-warnung_umstellung_11s.md
@@ -13,7 +13,7 @@ und sie ist außerdem nötig, weil die [Basis](https://wiki.freifunk.net/Gluon) 
 
 Die ganze Umstellung ist technisch komplex, aber wir haben uns ein Verfahren ausgedacht, welches dafür sorgt, dass die Umstellung problemlos und beinahe unbemerkt über die Bühne geht:  
 Am **Stichtag 5. März 2020** werden alle Knoten im Netz gleichzeitig ihr Mesh-Protokoll von IBSS auf 11s umstellen.
-Zumindest werden das alle Knoten tun, die mit der aktuellen Stable-Firmware [2019.1.1-bremen1](https://wiki.ffhb.de/Firmware/Changelog#freifunk-bremen-versionen_2019-1-1-bremen1) laufen. Das Update wird bereits vor der Installation komplett heruntergeladen, sodass sich keine Download-Abbrüche ergeben.
+Zumindest werden das alle Knoten tun, die mit der aktuellen Stable-Firmware [2019.1.1-bremen1](https://wiki.bremen.freifunk.net/Firmware/Changelog#freifunk-bremen-versionen_2019-1-1-bremen1) laufen. Das Update wird bereits vor der Installation komplett heruntergeladen, sodass sich keine Download-Abbrüche ergeben.
 
 **Was ist also zu beachten?**
 - Schaltet am besten den **Autoupdater** auf euren Knoten ein (z.B. auf `stable`). Dann wird euer Knoten bis zum 5.3.2020 automatisch das Update installieren und ist für die Umstellung bereit.

--- a/_posts/2020-06-10-Papageienhaus.md
+++ b/_posts/2020-06-10-Papageienhaus.md
@@ -4,8 +4,8 @@ title:  "Neuer Standort: Papageien-Hochhaus"
 author: Louis und Yannik
 date:   2020-06-10 19:19:00 +0200
 ---
-Funk in alle Richtungen! Seit Mitte April stehen auf dem [Jakobus-Hochhaus](https://map.ffhb.de/#!/de/map/30b5c26e86dc) in der Bremer Bahnhofsvorstadt Freifunk-Geräte auf dem Dach. Das Gebäude wird auch liebevoll Papageien-Haus genannt.
-Internet kommt über eine Richtfunkverbindung vom [Schlachthof](https://map.ffhb.de/#!/de/map/e8de27590eb2). Dort wird der Anschluss durch die Bremer Firma [LWLcom](https://www.lwlcom.com) gesponsert.
+Funk in alle Richtungen! Seit Mitte April stehen auf dem [Jakobus-Hochhaus](https://map.bremen.freifunk.net/#!/de/map/30b5c26e86dc) in der Bremer Bahnhofsvorstadt Freifunk-Geräte auf dem Dach. Das Gebäude wird auch liebevoll Papageien-Haus genannt.
+Internet kommt über eine Richtfunkverbindung vom [Schlachthof](https://map.bremen.freifunk.net/#!/de/map/e8de27590eb2). Dort wird der Anschluss durch die Bremer Firma [LWLcom](https://www.lwlcom.com) gesponsert.
 
 <a  href="/blog/files/2020-06-20/papageienhaus_screenshot1.jpg"><img  src="/blog/files/2020-06-20/papageienhaus_screenshot1.jpg"  alt="Screenshot der Freifunk-Karte"  style="max-height:300px"></a>
 

--- a/ffapi/bremen.json
+++ b/ffapi/bremen.json
@@ -109,7 +109,7 @@
       "name": "Kalendar",
       "category": "ics",
       "type": "ICS",
-      "url": "https://cloud.ffhb.de/remote.php/dav/public-calendars/rcPxo5enJc75etx5?export"
+      "url": "https://cloud.bremen.freifunk.net/remote.php/dav/public-calendars/rcPxo5enJc75etx5?export"
     }
   ],
   "nodeMaps": [
@@ -136,7 +136,7 @@
     "club": {
       "name": "Förderverein Freifunk Bremen e.V.",
       "url": "https://bremen.freifunk.net/verein/",
-      "email": "vereinsvorstand@lists.ffhb.de"
+      "email": "vereinsvorstand@lists.bremen.freifunk.net"
     },
     "donations": {
       "bankaccount": {

--- a/kontakt.md
+++ b/kontakt.md
@@ -32,4 +32,4 @@ Bremen](https://www.hackerspace-bremen.de/anfahrt/). Schau doch mal vorbei, wir
 freuen uns immer über neue Gesichter!
 
 ## Mailingliste
-Für Interessierte besteht außerdem die Möglichkeit, unsere [Mailingliste](https://lists.ffhb.de/mailman/listinfo/ff-bremen/) zu abonnieren. Auf ihr wird diskutiert und ausgetauscht.
+Für Interessierte besteht außerdem die Möglichkeit, unsere [Mailingliste](https://lists.bremen.freifunk.net/mailman/listinfo/ff-bremen/) zu abonnieren. Auf ihr wird diskutiert und ausgetauscht.


### PR DESCRIPTION
This is necessary so that these links are not marked as "external" (see PR #110).