### PR TITLE
add landing page for insta link

### DIFF
--- a/insta/index.md
+++ b/insta/index.md
@@ -6,6 +6,7 @@ category_id: 0
 ## Instagram
 <a class="btn" href="https://bremen.freifunk.net/to/videokonf" target="_blank">Videokonferenz (1.&3. Fr./Monat, 19:30 Uhr)</a>
 
-<a class="btn" href="https://bremen.freifunk.net/blog/2020/03/17/freifunk-hilft.html">Freifunk für Schüler (PDF)</a>
+<a class="btn" href="https://bremen.freifunk.net/blog/2020/03/17/freifunk-hilft.html">Freifunk für Schüler (Blogpost)</a>
+<a class="btn" href="https://bremen.freifunk.net/blog/files/2020-03-17/Freifunk_Hilft_Schuelern.pdf">Freifunk für Schüler (PDF)</a>
 
 <a class="btn" href="../kontakt.html">Kontakt</a>

--- a/insta/index.md
+++ b/insta/index.md
@@ -1,0 +1,11 @@
+---
+layout: default
+title: Instagram
+category_id: 0
+---
+## Instagram
+<a class="btn" href="https://bremen.freifunk.net/to/videokonf" target="_blank">Videokonferenz (1.&3. Fr./Monat, 19:30 Uhr)</a>
+
+<a class="btn" href="https://bremen.freifunk.net/blog/2020/03/17/freifunk-hilft.html">Freifunk für Schüler (PDF)</a>
+
+<a class="btn" href="../kontakt.html">Kontakt</a>


### PR DESCRIPTION
Bei Instagram kann man im Profil nur einen Link angeben. Um auf unterschiedliche Inhalte verlinken zu können, ist diese Seite praktisch.