### PR TITLE
feat(post): add release stabil 2021 and testing 2023

### DIFF
--- a/_posts/2023-07-20-release-2021.md
+++ b/_posts/2023-07-20-release-2021.md
@@ -5,26 +5,27 @@ author: Geno
 date:   2023-07-21 20:08:00 +0100
 ---
 
-Nachdem die Testing-Firmware [2021.1.2+bremen1](https://wiki.bremen.freifunk.net/Firmware/Changelog.md#2021-1-2-bremen1) nun seit acht Monate ohne schwerwigende Probleme im Einsatz ist,
- diese Version zur Stable-Firmware zu befördern.
+Nachdem die Testing-Firmware [2021.1.2+bremen1](https://wiki.bremen.freifunk.net/Firmware/Changelog.md#2021-1-2-bremen1) nun seit acht Monaten ohne schwerwiegende Probleme im Einsatz ist,
+ befördern wir diese nun zur neuen Stable-Firmware.
 
 Diese Version ist wichtig für zukünftige Updates und ist daher zwingend notwendig, bevor wir vielleicht auf [2023.1](https://wiki.ffhb.de/Firmware/Changelog.md#2023-1) umstellen.
 
-Doch viel wichtiger, die noch ca. 46 Stück des TP-Link WR841 bekommen hiermit letztes Update.
-Wir haben zwar bereits in [Zukunft des TP-Link WR841](/blog/2020/07/21/zukunft-841.html) im Jahre 2020 davor gewarnt.
-Nun ist es so weit, die 4MB Flash und 32MB RAM Modelle haben ab jetzt quasi ausgedient.
+Wir haben bereits in [Zukunft des TP-Link WR841](/blog/2020/07/21/zukunft-841.html) im Jahre 2020 davor gewarnt,
+ nun ist es so weit: 
+Die 4MB Flash und 32MB RAM Modelle haben ab jetzt quasi ausgedient.
+Damit bekommen die ~46 verbliebenen des TP-Link WR841 hiermit ihr letztes Update.
 
-Die neue Stable-Version wird seit Dienstag automatisch auf allen Knoten im Bremer Freifunk-Netz installiert,
- auf denen automatische Upgrades für die “stable”-Version aktiviert sind.
+Die neue "stable"-Version wird seit Dienstag automatisch auf allen Knoten im Bremer Freifunk-Netz installiert,
+ auf denen automatische Upgrades für die "stable"-Version aktiviert sind.
 Wer das automatische Upgrade deaktiviert hat,
  findet die Firmware für ein manuelles Upgrade auch auf [downloads.bremen.freifunk.net](https://downloads.bremen.freifunk.net).
 
 ## Neue Testing-Firmware
-Neben der neuen Stable-Version gibt es jetzt mit der [2023.1+bremen1](https://wiki.bremen.freifunk.net/Firmware/Changelog.md#2023-1-bremen1) auch schon wieder eine neue Testing-Version.
-Diese wird seit Sonntag Nachmittag an alle Knoten verteilt, die automatische Upgrades für die “testing”-Version aktiviert haben.
+Neben der neuen "stable"-Version gibt es jetzt mit der [2023.1+bremen1](https://wiki.bremen.freifunk.net/Firmware/Changelog.md#2023-1-bremen1) auch schon wieder eine neue "testing"-Version.
+Diese wird seit Sonntag Nachmittag an alle Knoten verteilt, die automatische Upgrades für die "testing"-Version aktiviert haben.
 Die Version enthält hauptsächlich ein Upgrade der darunterliegenden Software ([Gluon](https://wiki.freifunk.net/Gluon) und [OpenWRT](https://openwrt.org)).
 
-Hierdurch geht Support für die Geräte mit wenig Memory und Flash verloren, doch genauso viele neue Geräte werden nun ebenfalls unterstützt.
+Hierdurch geht Support für die Geräte mit wenig RAM und Flash verloren, doch genauso viele neue Geräte werden nun ebenfalls unterstützt.
 
 Des Weiteren ist es nun möglich, viel genauer [Rollen](https://github.com/freifunk-gluon/gluon/pull/2688) (Uplink, Mesh und Client) auf den Interfaces (z.B. WAN und LAN) zu verteilen.
 Zudem gibt es nun Support für Mobilfunk-Modems und DNS Caching auf den Routern wird wieder unterstützt.

--- a/_posts/2023-07-20-release-2021.md
+++ b/_posts/2023-07-20-release-2021.md
@@ -1,0 +1,37 @@
+---
+layout: post
+title:  "Firmware 2021 - letzte mit 8MB support"
+author: Geno
+date:   2023-07-21 20:08:00 +0100
+---
+
+Nachdem die Testing-Firmware [2021.1.2+bremen1](https://wiki.bremen.freifunk.net/Firmware/Changelog.md#2021-1-2-bremen1) nun seit acht Monate ohne schwerwigende Probleme im Einsatz ist,
+ diese Version zur Stable-Firmware zu befördern.
+
+Diese Version ist wichtig für zukünftige Updates und ist daher zwingend notwendig, bevor wir vielleicht auf [2023.1](https://wiki.ffhb.de/Firmware/Changelog.md#2023-1) umstellen.
+
+Doch viel wichtiger, die noch ca. 46 Stück des TP-Link WR841 bekommen hiermit letztes Update.
+Wir haben zwar bereits in [Zukunft des TP-Link WR841](/blog/2020/07/21/zukunft-841.html) im Jahre 2020 davor gewarnt.
+Nun ist es so weit, die 4MB Flash und 32MB RAM Modelle haben ab jetzt quasi ausgedient.
+
+Die neue Stable-Version wird seit Dienstag automatisch auf allen Knoten im Bremer Freifunk-Netz installiert,
+ auf denen automatische Upgrades für die “stable”-Version aktiviert sind.
+Wer das automatische Upgrade deaktiviert hat,
+ findet die Firmware für ein manuelles Upgrade auch auf [downloads.bremen.freifunk.net](https://downloads.bremen.freifunk.net).
+
+## Neue Testing-Firmware
+Neben der neuen Stable-Version gibt es jetzt mit der [2023.1+bremen1](https://wiki.bremen.freifunk.net/Firmware/Changelog.md#2023-1-bremen1) auch schon wieder eine neue Testing-Version.
+Diese wird seit Sonntag Nachmittag an alle Knoten verteilt, die automatische Upgrades für die “testing”-Version aktiviert haben.
+Die Version enthält hauptsächlich ein Upgrade der darunterliegenden Software ([Gluon](https://wiki.freifunk.net/Gluon) und [OpenWRT](https://openwrt.org)).
+
+Hierdurch geht Support für die Geräte mit wenig Memory und Flash verloren, doch genauso viele neue Geräte werden nun ebenfalls unterstützt.
+
+Des Weiteren ist es nun möglich, viel genauer [Rollen](https://github.com/freifunk-gluon/gluon/pull/2688) (Uplink, Mesh und Client) auf den Interfaces (z.B. WAN und LAN) zu verteilen.
+Zudem gibt es nun Support für Mobilfunk-Modems und DNS Caching auf den Routern wird wieder unterstützt.
+
+## Feedback
+
+Falls ihr Probleme mit der neuen Firmware bemerkt oder Fragen habt,
+schreibt auf der [Mailingliste](https://lists.bremen.freifunk.net/mailman/listinfo/ff-bremen/),
+kommt zum [Treffen](/kontakt.html#treffen),
+oder tauscht euch im [Chat](https://webirc.hackint.org/#ircs://irc.hackint.org/#ffhb?nick=Gast_?) mit uns aus.

--- a/_posts/2023-09-08-release-2021.md
+++ b/_posts/2023-09-08-release-2021.md
@@ -1,24 +1,24 @@
 ---
 layout: post
-title:  "Firmware 2021 - letzte mit 8MB support"
+title:  "Firmware 2021 - letzte mit 4MB Flash und 32MB RAM support"
 author: Geno
-date:   2023-07-21 20:08:00 +0100
+date:   2023-09-08 20:08:00 +0100
 ---
 
 Nachdem die Testing-Firmware [2021.1.2+bremen1](https://wiki.bremen.freifunk.net/Firmware/Changelog.md#2021-1-2-bremen1) nun seit acht Monaten ohne schwerwiegende Probleme im Einsatz ist,
  befördern wir diese nun zur neuen Stable-Firmware.
 
-Diese Version ist wichtig für zukünftige Updates und ist daher zwingend notwendig, bevor wir vielleicht auf [2023.1](https://wiki.ffhb.de/Firmware/Changelog.md#2023-1) umstellen.
+Diese Version ist wichtig für zukünftige Updates und ist daher zwingend notwendig, bevor wir vielleicht auf [2023.1](https://wiki.bremen.freifunk.net/Firmware/Changelog.md#2023-1) umstellen.
 
-Wir haben bereits in [Zukunft des TP-Link WR841](/blog/2020/07/21/zukunft-841.html) im Jahre 2020 davor gewarnt,
+Wir haben bereits in einem [früheren Blogpost](/blog/2020/07/21/zukunft-841.html) davor gewarnt,
  nun ist es so weit: 
 Die 4MB Flash und 32MB RAM Modelle haben ab jetzt quasi ausgedient.
-Damit bekommen die ~46 verbliebenen des TP-Link WR841 hiermit ihr letztes Update.
+Damit bekommen die ~130 verbliebenen des TP-Link WR841 und die ~40 anderen [ähnlichen betroffenen Modelle](https://gluon.readthedocs.io/en/latest/releases/v2022.1.html#removed-devices) hiermit ihr letztes Update.
 
 Die neue "stable"-Version wird seit Dienstag automatisch auf allen Knoten im Bremer Freifunk-Netz installiert,
  auf denen automatische Upgrades für die "stable"-Version aktiviert sind.
 Wer das automatische Upgrade deaktiviert hat,
- findet die Firmware für ein manuelles Upgrade auch auf [downloads.bremen.freifunk.net](https://downloads.bremen.freifunk.net).
+ findet die Firmware für ein manuelles Upgrade auch auf [downloads.bremen.freifunk.net](https://downloads.bremen.freifunk.net/firmware/all/2021.1.2+bremen1/).
 
 ## Neue Testing-Firmware
 Neben der neuen "stable"-Version gibt es jetzt mit der [2023.1+bremen1](https://wiki.bremen.freifunk.net/Firmware/Changelog.md#2023-1-bremen1) auch schon wieder eine neue "testing"-Version.

--- a/_posts/2023-09-08-release-2021.md
+++ b/_posts/2023-09-08-release-2021.md
@@ -20,16 +20,6 @@ Die neue "stable"-Version wird seit Dienstag automatisch auf allen Knoten im Bre
 Wer das automatische Upgrade deaktiviert hat,
  findet die Firmware für ein manuelles Upgrade auch auf [downloads.bremen.freifunk.net](https://downloads.bremen.freifunk.net/firmware/all/2021.1.2+bremen1/).
 
-## Neue Testing-Firmware
-Neben der neuen "stable"-Version gibt es jetzt mit der [2023.1+bremen1](https://wiki.bremen.freifunk.net/Firmware/Changelog.md#2023-1-bremen1) auch schon wieder eine neue "testing"-Version.
-Diese wird seit Sonntag Nachmittag an alle Knoten verteilt, die automatische Upgrades für die "testing"-Version aktiviert haben.
-Die Version enthält hauptsächlich ein Upgrade der darunterliegenden Software ([Gluon](https://wiki.freifunk.net/Gluon) und [OpenWRT](https://openwrt.org)).
-
-Hierdurch geht Support für die Geräte mit wenig RAM und Flash verloren, doch genauso viele neue Geräte werden nun ebenfalls unterstützt.
-
-Des Weiteren ist es nun möglich, viel genauer [Rollen](https://github.com/freifunk-gluon/gluon/pull/2688) (Uplink, Mesh und Client) auf den Interfaces (z.B. WAN und LAN) zu verteilen.
-Zudem gibt es nun Support für Mobilfunk-Modems und DNS Caching auf den Routern wird wieder unterstützt.
-
 ## Feedback
 
 Falls ihr Probleme mit der neuen Firmware bemerkt oder Fragen habt,

--- a/_posts/2023-09-08-release-2021.md
+++ b/_posts/2023-09-08-release-2021.md
@@ -2,7 +2,7 @@
 layout: post
 title:  "Firmware 2021 - letzte mit 4MB Flash und 32MB RAM support"
 author: Geno
-date:   2023-09-08 20:08:00 +0100
+date:   2023-09-09 10:08:00 +0100
 ---
 
 Nachdem die Testing-Firmware [2021.1.2+bremen1](https://wiki.bremen.freifunk.net/Firmware/Changelog.md#2021-1-2-bremen1) nun seit acht Monaten ohne schwerwiegende Probleme im Einsatz ist,
@@ -15,7 +15,7 @@ Wir haben bereits in einem [früheren Blogpost](/blog/2020/07/21/zukunft-841.htm
 Die 4MB Flash und 32MB RAM Modelle haben ab jetzt quasi ausgedient.
 Damit bekommen die ~130 verbliebenen des TP-Link WR841 und die ~40 anderen [ähnlichen betroffenen Modelle](https://gluon.readthedocs.io/en/latest/releases/v2022.1.html#removed-devices) hiermit ihr letztes Update.
 
-Die neue "stable"-Version wird seit Dienstag automatisch auf allen Knoten im Bremer Freifunk-Netz installiert,
+Die neue "stable"-Version wird ab Dienstag automatisch auf allen Knoten im Bremer Freifunk-Netz installiert,
  auf denen automatische Upgrades für die "stable"-Version aktiviert sind.
 Wer das automatische Upgrade deaktiviert hat,
  findet die Firmware für ein manuelles Upgrade auch auf [downloads.bremen.freifunk.net](https://downloads.bremen.freifunk.net/firmware/all/2021.1.2+bremen1/).


### PR DESCRIPTION
Vorschau: https://github.com/FreifunkBremen/bremen.freifunk.net/blob/release-2021/_posts/2023-09-08-release-2021.md